### PR TITLE
Lower Ruby version requirement to >= 2.4.0 (v0.1.2)

### DIFF
--- a/lib/usecompass/version.rb
+++ b/lib/usecompass/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Usecompass
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/usecompass.gemspec
+++ b/usecompass.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Usecompass helps maintain clean layered architecture by checking that controllers call usecases and usecases have corresponding specs"
   spec.homepage = "https://github.com/Akito-n/useCompass"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
- Change minimum Ruby version from 2.7.0 to 2.4.0
- Bump version to 0.1.2
- Improves compatibility with older Rails projects

🤖 Generated with Claude Code