### PR TITLE
カスタムspecマッピング機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Usecompass
 
-A tool to guide your Rails usecase architecture by ensuring controllers call usecases and usecases have corresponding specs.
+A comprehensive tool to guide your Rails architecture by ensuring controllers call usecases, usecases have specs, rake tasks follow best practices, and all components have proper test coverage.
+
+## Features
+
+- ✅ **Controller Architecture**: Ensure controllers delegate to usecases
+- ✅ **Usecase Testing**: Verify every usecase has corresponding spec
+- ✅ **Rake Task Architecture**: Ensure rake tasks use usecases for business logic
+- ✅ **Rake Task Testing**: Verify every rake task has corresponding spec
+- ✅ **Individual Check Options**: Run specific checks with `-C`, `-S`, `-R` flags
+- ✅ **Custom Spec Mappings**: Support non-standard spec file naming conventions
+- ✅ **Flexible Exclusions**: Configure exclusions for controllers, actions, files
+- ✅ **CI/CD Integration**: Exit codes for build pipeline integration
 
 ## Installation
 
@@ -56,6 +67,12 @@ $ usecompass init --force           # Force overwrite existing config file
 $ usecompass -r /path/to/project    # Specify project root
 $ usecompass -c /path/to/config.yml # Specify config file
 $ usecompass --help                 # Show help
+
+# Individual check options
+$ usecompass -C                     # Check controllers only
+$ usecompass -S                     # Check usecase specs only  
+$ usecompass -R                     # Check rake usecase calls only
+$ usecompass -R -S                  # Check rake specs only
 ```
 
 ## Configuration
@@ -79,6 +96,24 @@ exclusions:
   usecase_specs:
     # Exclude usecases from spec requirement
     - "layered/usecase/legacy/migration_usecase.rb"
+  
+  rake_specs:
+    # Exclude rake files from spec requirement
+    - "lib/tasks/legacy/old_task.rake"
+
+# Custom spec file mappings for non-standard naming
+custom_mappings:
+  rakes:
+    # Map rake files to their corresponding spec files
+    - rake_file: "lib/tasks/organization_role_resource.rake"
+      spec_file: "spec/lib/tasks/org_role_spec.rb"
+    - rake_file: "lib/tasks/hoge_one.rake"
+      spec_file: "spec/lib/tasks/hoge_one_1_spec.rb"
+  
+  usecases:
+    # Map usecase files to their corresponding spec files
+    - usecase_file: "layered/usecase/some_usecase.rb"
+      spec_file: "spec/layered/usecase/some_custom_spec.rb"
 ```
 
 ## What it checks
@@ -115,6 +150,43 @@ Ensures that every usecase file has a corresponding spec file.
 
 - `layered/usecase/orders/create_order_usecase.rb` → `spec/layered/usecase/orders/create_order_usecase_spec.rb`
 - `app/usecases/create_order_usecase.rb` → `spec/usecases/create_order_usecase_spec.rb`
+
+### 3. Rake tasks call usecases
+
+Ensures that rake tasks call usecase classes instead of implementing business logic directly.
+
+**Good:**
+```ruby
+task :process_orders do
+  ProcessOrdersUsecase.new.perform
+end
+```
+
+**Bad:**
+```ruby
+task :process_orders do
+  # Business logic directly in rake task
+  Order.pending.each do |order|
+    order.process!
+    OrderMailer.confirmation(order).deliver
+  end
+end
+```
+
+### 4. Rake tasks have specs
+
+Ensures that every rake task file has a corresponding spec file.
+
+- `lib/tasks/orders.rake` → `spec/lib/tasks/orders_spec.rb`
+- `lib/tasks/admin/cleanup.rake` → `spec/lib/tasks/admin/cleanup_spec.rb`
+
+### 5. Custom spec mappings
+
+For projects with non-standard naming conventions, you can define custom mappings:
+
+- Instead of `organization_role_resource_spec.rb`, use `org_role_spec.rb`
+- Map specific files to their custom spec locations
+- Support for both rake tasks and usecases
 
 ## Exit codes
 

--- a/lib/usecompass/cli.rb
+++ b/lib/usecompass/cli.rb
@@ -174,6 +174,22 @@ module Usecompass
           usecase_specs:
             # Usecases that don't need specs (e.g., legacy code)
             # - "layered/usecase/legacy/migration_usecase.rb"
+          
+          rake_specs:
+            # Rake files that don't need specs
+            # - "lib/tasks/legacy/old_task.rake"
+
+        # Custom spec file mappings for non-standard naming
+        custom_mappings:
+          rakes:
+            # Map rake files to their corresponding spec files when naming doesn't follow convention
+            # - rake_file: "lib/tasks/hoge_one.rake"
+            #   spec_file: "spec/lib/tasks/hoge_one_1_spec.rb"
+          
+          usecases:
+            # Map usecase files to their corresponding spec files when naming doesn't follow convention
+            # - usecase_file: "layered/usecase/some_usecase.rb"
+            #   spec_file: "spec/layered/usecase/some_custom_spec.rb"
       YAML
 
       File.write(config_path, config_content)

--- a/lib/usecompass/rake_spec_analyzer.rb
+++ b/lib/usecompass/rake_spec_analyzer.rb
@@ -39,11 +39,29 @@ module Usecompass
     def derive_spec_path(rake_file)
       relative_path = rake_file.sub(@root_path + '/', '')
       
-      # lib/tasks/xxx/yyy.rake -> spec/lib/tasks/xxx/yyy_spec.rb
+      # Check for custom mapping first
+      custom_mapping = find_custom_rake_mapping(relative_path)
+      if custom_mapping
+        return File.join(@root_path, custom_mapping)
+      end
+      
+      # Default mapping: lib/tasks/xxx/yyy.rake -> spec/lib/tasks/xxx/yyy_spec.rb
       spec_path = relative_path.sub('lib/', 'spec/lib/')
       spec_path = spec_path.sub('.rake', '_spec.rb')
       
       File.join(@root_path, spec_path)
+    end
+
+    def find_custom_rake_mapping(rake_file_relative_path)
+      custom_mappings = @config.dig('custom_mappings', 'rakes') || []
+      
+      custom_mappings.each do |mapping|
+        if mapping['rake_file'] == rake_file_relative_path
+          return mapping['spec_file']
+        end
+      end
+      
+      nil
     end
   end
 end

--- a/lib/usecompass/usecase_analyzer.rb
+++ b/lib/usecompass/usecase_analyzer.rb
@@ -51,6 +51,13 @@ module Usecompass
     def derive_spec_path(usecase_file)
       relative_path = usecase_file.sub(@root_path + '/', '')
       
+      # Check for custom mapping first
+      custom_mapping = find_custom_usecase_mapping(relative_path)
+      if custom_mapping
+        return File.join(@root_path, custom_mapping)
+      end
+      
+      # Default mapping logic
       # layered/usecase/xxx/yyy_usecase.rb -> spec/layered/usecase/xxx/yyy_usecase_spec.rb
       if relative_path.start_with?('layered/')
         spec_path = relative_path.sub('layered/', 'spec/layered/')
@@ -66,6 +73,18 @@ module Usecompass
       spec_path = spec_path.sub('_usecase.rb', '_usecase_spec.rb')
       
       File.join(@root_path, spec_path)
+    end
+
+    def find_custom_usecase_mapping(usecase_file_relative_path)
+      custom_mappings = @config.dig('custom_mappings', 'usecases') || []
+      
+      custom_mappings.each do |mapping|
+        if mapping['usecase_file'] == usecase_file_relative_path
+          return mapping['spec_file']
+        end
+      end
+      
+      nil
     end
   end
 end

--- a/lib/usecompass/version.rb
+++ b/lib/usecompass/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Usecompass
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
## Summary
• rakeファイルとusecaseファイルの非標準spec命名に対応するカスタムマッピング機能を追加
• usecompass.ymlでcustom_mappingsセクションを設定可能
• 複数のファイルマッピングを配列形式で管理

## 新機能
### カスタムspecマッピング
通常の命名規則に従わないspecファイルを個別に指定可能：

```yaml
custom_mappings:
  rakes:
    - rake_file: "lib/tasks/hoge_one.rake"
      spec_file: "spec/lib/tasks/hoge_one_1_spec.rb"
    - rake_file: "lib/tasks/special_task.rake"  
      spec_file: "spec/lib/tasks/special_custom_spec.rb"
      
  usecases:
    - usecase_file: "layered/usecase/some_usecase.rb"
      spec_file: "spec/layered/usecase/some_custom_spec.rb"
```

### 追加の除外設定
- `rake_specs`: rakeファイルのspec除外設定を追加

## 技術的実装
- **RakeSpecAnalyzer**: `find_custom_rake_mapping()`メソッドでカスタムマッピング対応
- **UsecaseAnalyzer**: `find_custom_usecase_mapping()`メソッドでカスタムマッピング対応  
- **ConfigLoader**: `custom_mappings`セクションの読み込み対応
- **CLI**: initコマンドでカスタムマッピングのテンプレート生成

## Test plan
- [x] 標準命名規則でのspec検出確認
- [x] カスタムマッピング設定でのspec検出確認
- [x] カスタムマッピング対象ファイルが存在しない場合の違反検出確認
- [x] 複数のカスタムマッピング設定動作確認
- [x] initコマンドでの新テンプレート生成確認

## Use Case
例：`organization_role_resource.rake`に対して、通常は`organization_role_resource_spec.rb`が期待されるが、実際には`org_role_spec.rb`として作成されている場合など、プロジェクト固有の命名規則に対応可能。

🤖 Generated with [Claude Code](https://claude.ai/code)